### PR TITLE
Fix: fix publish workflows

### DIFF
--- a/.github/workflows/publish-to-test.yml
+++ b/.github/workflows/publish-to-test.yml
@@ -3,7 +3,10 @@ name: Publish to TestPyPI
 on:
   push:
     branches:
-      - develop
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Publish
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 
 jobs:
   build:


### PR DESCRIPTION
**Fixed:**
- The *Publish* workflow will be triggered on tag pushes (only if tag starts with `v`).
- The *Publish to TestPyPI* workflow will be triggered on pushes and pull requests to `main` branch.